### PR TITLE
Add better exception handling mechanism

### DIFF
--- a/src/main/java/edu/rice/cs/caper/bayou/core/dsl/DAPICall.java
+++ b/src/main/java/edu/rice/cs/caper/bayou/core/dsl/DAPICall.java
@@ -225,14 +225,11 @@ public class DAPICall extends DASTNode
     private Executable getConstructorOrMethod() throws SynthesisException {
         String qualifiedName = _call.substring(0, _call.indexOf("("));
         String className = qualifiedName.substring(0, qualifiedName.lastIndexOf("."));
-        Class cls = null;
-        try
-        {
+        Class cls;
+        try {
             cls = Environment.getClass(className);
-        }
-        catch (ClassNotFoundException e)
-        {
-            throw new SynthesisException(e);
+        } catch (ClassNotFoundException e) {
+            throw new SynthesisException(SynthesisException.ClassNotFoundInLoader);
         }
 
         /* find the method in the class */
@@ -260,6 +257,6 @@ public class DAPICall extends DASTNode
                 return c;
         }
 
-        throw new SynthesisException("Contructor or method not found: " + qualifiedName);
+        throw new SynthesisException(SynthesisException.MethodOrConstructorNotFound);
     }
 }

--- a/src/main/java/edu/rice/cs/caper/bayou/core/synthesizer/Environment.java
+++ b/src/main/java/edu/rice/cs/caper/bayou/core/synthesizer/Environment.java
@@ -41,12 +41,8 @@ public class Environment {
         imports = new HashSet<>();
     }
 
-    public Expression addVariable(Class type) {
-        try {
-            return searchOrAddVariable(type, false);
-        } catch (SynthesisException e) {
-            throw new Error("SynthesisException was thrown in addVariable()! This shouldn't occur.");
-        }
+    public Expression addVariable(Class type) throws SynthesisException {
+        return searchOrAddVariable(type, false);
     }
 
     public Expression searchOrAddVariable(Class type, boolean search) throws SynthesisException {
@@ -55,7 +51,7 @@ public class Environment {
         if (search)
             if ((expr = enumerator.search(type)) != null)
                 return expr;
-            else throw new SynthesisException("Could not find variable of type " + type.getName());
+            else throw new SynthesisException(SynthesisException.TypeNotFoundDuringSearch);
 
         /* construct a nice name for the variable */
         String name = "";

--- a/src/main/java/edu/rice/cs/caper/bayou/core/synthesizer/ParseException.java
+++ b/src/main/java/edu/rice/cs/caper/bayou/core/synthesizer/ParseException.java
@@ -31,4 +31,8 @@ public class ParseException extends Exception {
     public ParseException(String message) {
         super(message);
     }
+
+    public ParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/edu/rice/cs/caper/bayou/core/synthesizer/SynthesisException.java
+++ b/src/main/java/edu/rice/cs/caper/bayou/core/synthesizer/SynthesisException.java
@@ -16,15 +16,54 @@ limitations under the License.
 package edu.rice.cs.caper.bayou.core.synthesizer;
 
 
-public class SynthesisException extends Exception
-{
-    public SynthesisException(String message)
-    {
-        super(message);
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SynthesisException extends RuntimeException {
+
+    public static final int CouldNotResolveBinding = 1000;
+    public static final int EvidenceNotInBlock = 1001;
+    public static final int EvidenceMixedWithCode = 1002;
+    public static final int MoreThanOneHole = 1003;
+    public static final int InvalidEvidenceType = 1004;
+    public static final int CouldNotEditDocument = 1005;
+    public static final int ClassNotFoundInLoader = 1006;
+    public static final int TypeNotFoundDuringSearch = 1007;
+    public static final int MethodOrConstructorNotFound = 1008;
+
+    private static final Map<Integer,String> toMessage;
+    static {
+        Map<Integer,String> _toMessage = new HashMap<>();
+        _toMessage.put(CouldNotResolveBinding,
+            "Could not resolve binding. Ensure CLASSPATH is set correctly.");
+        _toMessage.put(EvidenceNotInBlock,
+            "Evidence should be given in a block.");
+        _toMessage.put(EvidenceMixedWithCode,
+            "Evidence calls should appear in a separate empty block.");
+        _toMessage.put(MoreThanOneHole,
+            "More than one hole for synthesis not currently supported.");
+        _toMessage.put(InvalidEvidenceType,
+            "Invalid evidence type given.");
+        _toMessage.put(CouldNotEditDocument,
+            "Could not edit document for some reason.");
+        _toMessage.put(ClassNotFoundInLoader,
+            "Class could not be found in class loader.");
+        _toMessage.put(TypeNotFoundDuringSearch,
+            "Type could not be found during combinatorial search.");
+        _toMessage.put(MethodOrConstructorNotFound,
+                "Method or constructor not found in class.");
+        toMessage = Collections.unmodifiableMap(_toMessage);
     }
 
-    public SynthesisException(Throwable cause)
-    {
-        super(cause);
+    private final int id;
+
+    public SynthesisException(int id) {
+        super(toMessage.get(id));
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
     }
 }

--- a/src/main/java/edu/rice/cs/caper/bayou/core/synthesizer/Synthesizer.java
+++ b/src/main/java/edu/rice/cs/caper/bayou/core/synthesizer/Synthesizer.java
@@ -67,7 +67,7 @@ public class Synthesizer {
                     programs.add(program);
                     synthesizedPrograms.add(visitor.synthesizedProgram);
                 }
-            } catch (Exception e) {
+            } catch (SynthesisException e) {
                 // do nothing and try next ast
             }
         }


### PR DESCRIPTION
There are now two types of exceptions thrown: ParseException (checked)
when there is a parsing error, and SynthesisException (uncheced) when
there is an error during evidence extraction or synthesis. This handles
issue #33 from the backend.