### PR TITLE
Check model type in AST server before loading it

### DIFF
--- a/src/main/python/bayou/core/model.py
+++ b/src/main/python/bayou/core/model.py
@@ -22,6 +22,7 @@ from bayou.core.data_reader import CHILD_EDGE, SIBLING_EDGE
 
 class Model():
     def __init__(self, config, infer=False):
+        assert config.model == 'core', 'Trying to load different model implementation: ' + config.model
         self.config = config
         if infer:
             config.batch_size = 1

--- a/src/main/python/bayou/core/utils.py
+++ b/src/main/python/bayou/core/utils.py
@@ -17,7 +17,7 @@ import argparse
 import re
 import tensorflow as tf
 
-CONFIG_GENERAL = ['latent_size', 'batch_size', 'num_epochs',
+CONFIG_GENERAL = ['model', 'latent_size', 'batch_size', 'num_epochs',
                   'learning_rate', 'print_step', 'alpha', 'beta']
 CONFIG_ENCODER = ['name', 'units', 'num_layers', 'tile']
 CONFIG_DECODER = ['units', 'num_layers', 'max_ast_depth']

--- a/src/main/python/bayou/experiments/low_level_evidences/model.py
+++ b/src/main/python/bayou/experiments/low_level_evidences/model.py
@@ -22,6 +22,7 @@ from bayou.experiments.low_level_evidences.data_reader import CHILD_EDGE, SIBLIN
 
 class Model():
     def __init__(self, config, infer=False):
+        assert config.model == 'lle', 'Trying to load different model implementation: ' + config.model
         self.config = config
         if infer:
             config.batch_size = 1

--- a/src/main/python/bayou/experiments/low_level_evidences/utils.py
+++ b/src/main/python/bayou/experiments/low_level_evidences/utils.py
@@ -20,7 +20,7 @@ import random
 from itertools import chain
 import tensorflow as tf
 
-CONFIG_GENERAL = ['latent_size', 'batch_size', 'num_epochs',
+CONFIG_GENERAL = ['model', 'latent_size', 'batch_size', 'num_epochs',
                   'learning_rate', 'print_step', 'alpha', 'beta']
 CONFIG_ENCODER = ['name', 'units', 'num_layers', 'tile']
 CONFIG_DECODER = ['units', 'num_layers', 'max_ast_depth']


### PR DESCRIPTION
This is to make it easier for the AST server to load different kinds of models without modifying code or providing any parameters.